### PR TITLE
refactor(delete document): remove default error because it is non-optional

### DIFF
--- a/LanguageTranslatorV3.playground/Pages/Document translation.xcplaygroundpage/Contents.swift
+++ b/LanguageTranslatorV3.playground/Pages/Document translation.xcplaygroundpage/Contents.swift
@@ -55,7 +55,7 @@ languageTranslator.deleteDocument(documentID: testDocumentID) {
     response, error in
     
     if let error = error {
-        print(error.localizedDescription ?? "unknown error")
+        print(error.localizedDescription)
         return
     }
     


### PR DESCRIPTION
Good catch @mkistler 