### PR TITLE
feat(discoveryv2): add discoveryv2 examples

### DIFF
--- a/DiscoveryV2.playground/Pages/Collections.xcplaygroundpage/Contents.swift
+++ b/DiscoveryV2.playground/Pages/Collections.xcplaygroundpage/Contents.swift
@@ -1,0 +1,18 @@
+//:## Collections
+
+import DiscoveryV2
+
+let discovery = setupDiscoveryV2()
+
+//:### List collections
+
+discovery.listCollections(projectID: projectID) {
+    response, error in
+    
+    guard let collections = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(collections)
+}

--- a/DiscoveryV2.playground/Pages/Component settings.xcplaygroundpage/Contents.swift
+++ b/DiscoveryV2.playground/Pages/Component settings.xcplaygroundpage/Contents.swift
@@ -1,0 +1,18 @@
+//:## Queries
+
+import DiscoveryV2
+
+let discovery = setupDiscoveryV2()
+
+//:### Configuration settings for components.
+
+discovery.getComponentSettings(projectID: projectID) {
+    response, error in
+    
+    guard let settings = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(results)
+}

--- a/DiscoveryV2.playground/Pages/Documents.xcplaygroundpage/Contents.swift
+++ b/DiscoveryV2.playground/Pages/Documents.xcplaygroundpage/Contents.swift
@@ -1,0 +1,50 @@
+//:## Documents
+
+import DiscoveryV2
+
+let discovery = setupDiscoveryV2()
+var documentID: String!
+
+//:### Add a document
+
+let url = Bundle.main.url(forResource: "KennedySpeech", withExtension: "html")
+let testDocument = try! Data(contentsOf: url!)
+
+discovery.addDocument(projectID: projectID, collectionID: collectionID, file: testDocument, filename: "test_file", fileContentType: "application/html", xWatsonDiscoveryForce: false) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+    
+    documentID = results.documentID
+
+    print(results)
+}
+
+//:### Update a document
+
+discovery.updateDocument(projectID: projectID, collectionID: collectionID, documentID: documentID, file: testDocument, filename: "updated_file", fileContentType: "text/html", xWatsonDiscoveryForce: false) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(results)
+}
+
+//:### Delete a document
+
+discovery.deleteDocument(projectID: projectID, collectionID: collectionID, documentID: documentID, xWatsonDiscoveryForce: false) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(results)
+}

--- a/DiscoveryV2.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/DiscoveryV2.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -1,0 +1,69 @@
+//:# Discovery V2
+//: This playground contains code examples for the Discovery V2 service.
+
+//: Please note that Discovery V2 is only available in the Cloud Pak for Data environment.
+//: To learn more about Cloud Pak for Data, go here.
+
+//: To use the Watson Developer Cloud Swift SDK in your application, specify it in your `Cartfile`:
+//:```
+//:github "watson-developer-cloud/swift-sdk"
+//:```
+
+//:Then run the following command to build the dependencies and frameworks:
+//:```bash
+//:carthage update --platform iOS
+//:```
+
+import DiscoveryV2
+
+let username = WatsonCredentials.DiscoveryV2Username
+let password = WatsonCredentials.DiscoveryV2Username
+let cp4dUrl = WatsonCredentials.DiscoveryV2CP4DUrl
+
+//:## Authentication
+let authenticator = WatsonCloudPakForDataAuthenticator(username: username, password: password, url: url)
+
+let discovery = Discovery(version: "2019-11-30", authenticator: authenticator)
+
+//:## Service URL
+
+// Set the URL for the service endpoint if needed
+if let serviceURL = WatsonCredentials.DiscoveryV1URL {
+    discovery.serviceURL = serviceURL
+}
+
+let projectID = "<your-project-id>"
+
+//:## Error handling
+
+discovery.listCollections(projectID: projectID) {
+    response, error in
+
+    if let error = error {
+        switch error {
+        case let .http(statusCode, message, metadata):
+            switch statusCode {
+            case .some(404):
+                // Handle Not Found (404) exception
+                print("Not found")
+            case .some(413):
+                // Handle Request Too Large (413) exception
+                print("Payload too large")
+            default:
+                if let statusCode = statusCode {
+                    print("Error - code: \(statusCode), \(message ?? "")")
+                }
+            }
+        default:
+            print(error.localizedDescription)
+        }
+        return
+    }
+
+    guard let collections = response?.result else {
+        print(error?.localizedDescription ?? "unknown error")
+        return
+    }
+
+    print(collections)
+}

--- a/DiscoveryV2.playground/Pages/Queries.xcplaygroundpage/Contents.swift
+++ b/DiscoveryV2.playground/Pages/Queries.xcplaygroundpage/Contents.swift
@@ -1,0 +1,57 @@
+//:## Queries
+
+import DiscoveryV2
+
+let discovery = setupDiscoveryV2()
+
+//:### Query a project
+
+discovery.query(projectID: projectID) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(results)
+}
+
+//:### Get Autocomplete Suggestions
+
+discovery.getAutocompletion(projectID: projectID, collectionIDs: [collectionID], prefix: "tes") {
+    response, error in
+    
+    guard let suggestions = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(suggestions)
+}
+
+//:### Query system notices
+
+discovery.queryNotices(projectID: projectID, naturalLanguageQuery: "warning", count: 10, highlight: false, spellingSuggestions: false) {
+    response, error in
+    
+    guard let notices = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(notices)
+}
+
+//:### List fields
+
+discovery.listFields(projectID: projectID) {
+    response, error in
+
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(notices)
+}

--- a/DiscoveryV2.playground/Pages/Training data.xcplaygroundpage/Contents.swift
+++ b/DiscoveryV2.playground/Pages/Training data.xcplaygroundpage/Contents.swift
@@ -1,0 +1,76 @@
+//:## Training data
+
+import DiscoveryV2
+
+let discovery = setupDiscoveryV2()
+let documentID = "<your-document-id>"
+let collectionID = "<your-collection-id>"
+var queryID: String!
+
+//:### List training queries
+
+discovery.listTrainingQueries(projectID: projectID) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(results)
+}
+
+//:### Delete training queries
+
+discovery.deleteTrainingQueries(projectID: projectID) {
+    _, error in
+    
+    if let error = error {
+        debugPrint(error.localizedDescription)
+        return
+    }
+}
+
+//:### Create training query
+let trainingExample = TrainingExample(documentID: documentID, collectionID: collectionID, relevance: 1)
+
+discovery.createTrainingQuery(projectID: projectID, naturalLanguageQuery: "test", filter: nil, examples: [trainingExample]) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+    
+    queryID = results.queryID
+
+    print(results)
+}
+
+//:### Get a training data query
+
+discovery.getTrainingQuery(projectID: projectID, queryID: queryID) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(results)
+}
+
+//:### Update a training query
+
+let trainingExample = TrainingExample(documentID: documentID, collectionID: collectionID, relevance: 1)
+
+discovery.updateTrainingQuery(projectID: projectID, queryID: queryID, naturalLanguageQuery: "updated", examples: [trainingExample]) {
+    response, error in
+    
+    guard let results = response?.result else {
+        print(error?.localizedDescription ?? "unexpected error")
+        return
+    }
+
+    print(results)
+}

--- a/DiscoveryV2.playground/Resources/KennedySpeech.html
+++ b/DiscoveryV2.playground/Resources/KennedySpeech.html
@@ -1,0 +1,767 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<!-- DW6 -->
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+	<link href="/styles/library.css" rel="stylesheet" type="text/css" media="screen" />
+	<link href="/styles/print.css" rel="stylesheet" type="text/css" media="print" /> 
+	<meta name="keywords" content="american government, american politics, united states, u.s., congress, political science, wallpaper, free, online, glossary, pictures, history, historical, documents, library, textbook, teaching, resources">
+	<meta name="description" content="American government & politics portal. Free online textbook, documents library and more.">
+	<meta name="Author" content="Jonathan D. Mott, Ph.D.">
+	<title>ThisNation.com--State of the Union Address</title>
+</head>
+<body> 
+
+<!-- Begin Banner --> 
+<div id="banner">
+  
+<span><img src="/images/banner.jpg">
+
+<script type="text/javascript"><!--
+google_ad_client = "pub-4028468449272970";
+/* 468x60, created 8/14/08 */
+google_ad_slot = "2920419469";
+google_ad_width = 468;
+google_ad_height = 60;
+//-->
+</script>
+<script type="text/javascript"
+src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
+</script>
+
+</span>
+</div>
+<div id="printbanner"><img src="/images/banner_print.jpg" width="399" height="72"></div>
+
+<div id="globalNav">    <a href="http://www.thisnation.com">Home</a> &bull; 
+	<a href="http://www.thisnation.com/library/">Library</a> &bull;  
+	<a href="http://www.thisnation.com/textbook">Online Textbook</a> &bull;   
+	<a href="http://www.thisnation.com/about.html">About ThisNation.com</a> 
+			
+	
+    
+	<div id="search"><!-- Search Google -->
+<FORM method=GET action=http://www.google.com/custom>
+<INPUT TYPE=text name=q size=20 maxlength=255 value="">
+<INPUT type=submit name=sa VALUE="Google Search">
+<INPUT type=hidden name=cof VALUE="S:http://www.thisnation.com;AH:left;LH:72;L:http://thisnation.com/images/google_banner.jpg;LW:399;AWFID:b95bfadc3e189708;">
+<input type=hidden name=domains value="thisnation.com">
+<input type=hidden name=sitesearch value="">
+<input type=hidden name=sitesearch value="thisnation.com" checked> 
+</FORM>
+<!-- Search Google -->
+</div>
+</div> 
+ 
+
+<!-- End Banner --> 
+
+<!--Begin NavBar --> 
+<div id="navBar"> 
+  <div id="date"><script language="JavaScript">
+<!-- Begin
+var months=new Array(13);
+months[1]="January";
+months[2]="February";
+months[3]="March";
+months[4]="April";
+months[5]="May";
+months[6]="June";
+months[7]="July";
+months[8]="August";
+months[9]="September";
+months[10]="October";
+months[11]="November";
+months[12]="December";
+var time=new Date();
+var lmonth=months[time.getMonth() + 1];
+var date=time.getDate();
+var year=time.getYear();
+if (year < 2000)    
+year = year + 1900; 
+document.write("<left>" + lmonth + " ");
+document.write(date + ", " + year + "</left>");
+// End -->
+</script></div>
+  <div id="navLinks"><a href="http://www.thisnation.com/index.html">Home</a>
+<a href="http://www.thisnation.com/library/index.html">Library</a>
+<a href="http://www.thisnation.com/about.html">About This Nation</a>
+<a href="http://www.thisnation.com/constitution.html">The Constitution</a>
+<a href="http://www.thisnation.com/federalism.html">Federalism</a>
+<a href="http://www.thisnation.com/executive.html">&#8226; Executive</a>
+<a href="http://www.thisnation.com/legislative.html">&#8226; Legislative</a>
+<a href="http://www.thisnation.com/judiciary.html">&#8226; Judiciary</a>
+<a href="http://www.thisnation.com/glossary.html">Glossary</a>
+<a href="http://www.thisnation.com/search.html">Search</a>
+<a href="http://www.thisnation.com/media/">Multimedia</a>
+<a href="http://www.thisnation.com/textbook">Online Textbook</a> 
+
+</div> 
+    <div id="navQuote"><p>&quot;If men were angels, no government would be necessary.&quot; <br><span>James Madison</span> </p>
+
+</div>
+	<div id="navAd"><p align="center"><a href="http://socialstudies.com/c/@0/Pages/index.html?+af@tn"><img src="/images/socialstudies.jpg" alt="Shop at SocialStudies.com" width="109" height="59" vspace="10" border="0"></a>
+</p>
+<div align="center">
+
+
+<script type="text/javascript"><!--
+google_ad_client = "pub-4028468449272970";
+/* 120x600, created 7/7/08 */
+google_ad_slot = "7917410058";
+google_ad_width = 120;
+google_ad_height = 600;
+//-->
+</script>
+<script type="text/javascript"
+src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
+</script>
+
+
+
+</div></div>
+</div> 
+
+<!--End NavBar --> 
+
+<!-- Begin Content --> 
+
+<div id="content"> 
+      <div id=breadcrumb><a href="/index.html">Home</a> > <a href="/library/index.html">Library</a> > <a href="/library/sotu/index.html">State
+      of the Union Address</a> &gt; John F. Kennedy  1962</div>
+      <div id="feature">
+    <h2> State of the Union Address
+      <br> 
+      John F. Kennedy </h2>
+    <h3 align="left"> <br>
+  11 January 1962</h3>
+    <p>Mr. Vice President, my old colleague from Massachusetts and your new Speaker,
+      John McCormack, Members of the 87th Congress, ladies and gentlemen: </p>
+    <p>This week we begin anew our joint and separate efforts to build the American
+      future. But, sadly, we build without a man who linked a long past with
+      the present and looked strongly to the future. &quot;Mister Sam&quot; Rayburn
+      is gone. Neither this House nor the Nation is the same without him. </p>
+    <p>Members of the Congress, the Constitution makes us not rivals for power
+      but partners for progress. We are all trustees for the American people,
+      custodians of the American heritage. It is my task to report the State
+      of the Union--to improve it is the task of us all. </p>
+    <p>In the past year, I have traveled not only across our own land but to
+      other lands-to the North and the South, and across the seas. And I have
+      found--as I am sure you have, in your travels--that people everywhere,
+      in spite of occasional disappointments, look to us--not to our wealth or
+      power, but to the splendor of our ideals. For our Nation is commissioned
+      by history to be either an observer of freedom's failure or the cause of
+      its success. Our overriding obligation in the months ahead is to fulfill
+      the world's hopes by fulfilling our own faith. </p>
+    <p>1. STRENGTHENING THE ECONOMY </p>
+    <p>That task must begin at home. For if we cannot fulfill our own ideals
+      here, we cannot expect others to accept them. And when the youngest child
+      alive today has grown to the cares of manhood, our position in the world
+      will be determined first of all by what provisions we make today--for his
+      education, his health, and his opportunities for a good home and a good
+      job and a good life. </p>
+    <p>At home, we began the year in the valley of recession--we completed it
+      on the high road of recovery and growth. With the help of new congressionally
+      approved or administratively increased stimulants to our economy, the number
+      of major surplus labor u areas has declined from 101
+      to 60; nonagricultural employment has increased by more than a million
+      jobs; and the average factory work-week has risen to well over 40 hours.
+      At year's end the economy which Mr. Khrushchev once called a &quot;stumbling
+      horse&quot; was racing to new records in consumer spending, labor income,
+      and industrial production. </p>
+    <p>We are gratified--but we are not satisfied. Too many unemployed are still
+      looking for the blessings of prosperity- As those who leave our schools
+      and farms demand new jobs, automation takes old jobs away. To expand our
+      growth and job opportunities, I urge on the Congress three measures: </p>
+    <p>(1) First, the Manpower Training and Development Act, to stop the waste
+      of able-bodied men and women who want to work, but whose only skill has
+      been replaced by a machine, or moved with a mill, or shut down with a mine; </p>
+    <p>(2) Second, the Youth Employment Opportunities Act, to help train and
+      place not only the one million young Americans who are both out of school
+      and out of work, but the twenty-six million young Americans entering the
+      labor market in this decade; and </p>
+    <p>(3) Third, the 8 percent tax credit for investment in machinery and equipment,
+      which, combined with planned revisions of depreciation allowances, will
+      spur our modernization, our growth, and our ability to compete abroad. </p>
+    <p>Moreover--pleasant as it may be to bask in the warmth of recovery--let
+      us not forget that we have suffered three recessions in the last 7 years.
+      The time to repair the roof is when the sun is shining--by filling three
+      basic gaps in our anti-recession protection. We need: </p>
+    <p>(1) First, presidential standby authority, subject to congressional veto,
+      to adjust personal income tax rates downward within a specified range and
+      time, to slow down an economic decline before it has dragged us all down;<br>
+  (2) Second, presidential standby authority, upon a given rise in the rate of
+  unemployment, to accelerate Federal and federally-aided capital improvement
+  programs; and </p>
+    <p>(3) Third, a permanent strengthening of our unemployment compensation
+      system--to maintain for our fellow citizens searching for a job who cannot
+      find it, their purchasing power and their living standards without constant
+      resort--as we have seen in recent years by the Congress and the administrations-to
+      temporary supplements. </p>
+    <p>If we enact this six-part program, we can show the whole world that a
+      free economy need not be an unstable economy--that a free system need not
+      leave men unemployed--and that a free society is not only the most productive
+      but the most stable form of organization yet fashioned by man. </p>
+    <p>II. FIGHTING INFLATION </p>
+    <p>But recession is only one enemy of a free economy--inflation is another.
+      Last year, 1961, despite rising production and demand, consumer prices
+      held almost steady--and wholesale prices declined. This is the best record
+      of overall price stability of any comparable period of recovery since the
+      end of World War II. </p>
+    <p>Inflation too often follows in the shadow of growth--while price stability
+      is made easy by stagnation or controls. But we mean to maintain both stability
+      and growth in a climate of freedom. </p>
+    <p>Our first line of defense against inflation is the good sense and public
+      spirit of business and labor--keeping their total increases in wages and
+      profits in step with productivity. There is no single statistical test
+      to guide each company and each union. But I strongly urge them--for their
+      country's interest, and for their own--to apply the test of the public
+      interest to these transactions. </p>
+    <p> Within
+      this same framework of growth and wage-price stability: </p>
+    <p>--This administration has helped keep our economy competitive by widening
+      the access of small business to credit and Government contracts, and by
+      stepping up the drive against monopoly, price-fixing, and racketeering; </p>
+    <p>--We will submit a Federal Pay Reform bill aimed at giving our classified,
+      postal, and other employees new pay scales more comparable to those of
+      private industry; </p>
+    <p>--We are holding the fiscal 1962 budget deficit far below the level incurred
+      after the last recession in 1958; and, finally, </p>
+    <p>--I am submitting for fiscal 1963 a balanced Federal Budget. </p>
+    <p> This
+      is a joint responsibility, requiring Congressional cooperation on appropriations,
+      and on three sources of income in particular: </p>
+    <p>(1) First, an increase in postal rates, to end the postal deficit; </p>
+    <p> (2)
+      Secondly, passage of the tax reforms previously urged, to remove unwarranted
+      tax preferences, and to apply to dividends and to interest the same withholding
+      requirements we have long applied to wages; and </p>
+    <p>(3) Third, extension of the present excise and corporation tax rates,
+      except for those changes--which will be recommended in a message--affecting
+      transportation. </p>
+    <p>III. GETTING AMERICA MOVING </p>
+    <p>But a stronger nation and economy require more than a balanced Budget.
+      They require progress in those programs that spur our growth and fortify
+      our strength. </p>
+    <p>CITIES </p>
+    <p>A strong America depends on its cities-America's glory, and sometimes
+      America's shame. To substitute sunlight for congestion and progress for
+      decay, we have stepped up existing urban renewal and housing programs,
+      and launched new ones--redoubled the attack on water pollution--speeded
+      aid to airports, hospitals, highways, and our declining mass transit systems--and
+      secured new weapons to combat organized crime, racketeering, and youth
+      delinquency, assisted by the coordinated and hard-hitting efforts of our
+      investigative services: the FBI, the Internal Revenue, the Bureau of Narcotics,
+      and many others. We shall need further anti-crime, mass transit, and transportation
+      legislation--and new tools to fight air pollution. And with all this effort
+      under way, both equity and commonsense require that our nation's urban
+      areas--containing three-fourths of our population--sit as equals at the
+      Cabinet table. I urge a new Department of Urban Affairs and Housing. </p>
+    <p>AGRICULTURE AND RESOURCES </p>
+    <p>A strong America also depends on its farms and natural resources. American
+      farmers took heart in 1961--from a billion dollar rise in farm income--and
+      from a hopeful start on reducing the farm surpluses. But we are still operating
+      under a patchwork accumulation of old laws, which cost us $1 billion a
+      year in CCC carrying charges alone, yet fail to halt rural poverty or boost
+      farm earnings. </p>
+    <p>Our task is to master and turn to fully fruitful ends the magnificent
+      productivity of our farms and farmers. The revolution on our own countryside
+      stands in the sharpest contrast to the repeated farm failures of the Communist
+      nations and is a source of pride to us all. Since 1950 our agricultural
+      output per man-hour has actually doubled! Without new, realistic measures,
+      it will someday swamp our farmers and our taxpayers in a national scandal
+      or a farm depression. </p>
+    <p>I will, therefore, submit to the Congress a new comprehensive farm program--tailored
+      to fit the use of our land and the supplies of each crop to the long-range
+      needs of the sixties--and designed to prevent chaos in the sixties with
+      a program of commonsense. </p>
+    <p>We also need for the sixties--if we are to bequeath our full national
+      estate to our heirs--a new long-range conservation and recreation program--expansion
+      of our superb national parks and forests--preservation of our authentic
+      wilderness areas-new starts on water and power projects as our population
+      steadily increases--and expanded REA generation and transmission loans. </p>
+    <p>CIVIL RIGHTS </p>
+    <p>But America stands for progress in human rights as well as economic affairs,
+      and a strong America requires the assurance of full and equal rights to
+      all its citizens, of any race or of any color. This administration has
+      shown as never before how much could be done through the full use of Executive
+      powers--through the enforcement of laws already passed by the Congress-through
+      persuasion, negotiation, and litigation, to secure the constitutional rights
+      of all: the right to vote, the right to travel Without hindrance across
+      State lines, and the right to free public education. </p>
+    <p>I issued last March a comprehensive order to guarantee the right to equal
+      employment opportunity in all Federal agencies and contractors. The Vice
+      President's Committee thus created has done much, including the voluntary &quot;Plans
+      for progress&quot; which, in all sections of the country, are achieving
+      a quiet but striking success in opening up to all races new professional,
+      supervisory, and other job opportunities. </p>
+    <p>But there is much more to be done--by the Executive, by the courts, and
+      by the Congress. Among the bills now pending before you, on which the executive
+      departments will comment in detail, are appropriate methods of strengthening
+      these basic rights which have our full support. The right to vote, for
+      example, should no longer be denied through such arbitrary devices on a
+      local level, sometimes abused, such as literacy tests and poll taxes. As
+      we approach the 100th anniversary, next January, of the Emancipation Proclamation,
+      let the acts of every branch of the Government--and every citizen--portray
+      that &quot;righteousness does exalt a nation.&quot; </p>
+    <p>HEALTH AND WELFARE </p>
+    <p>Finally, a strong America cannot neglect the aspirations of its
+      citizens--the welfare of the needy, the health care of the elderly, the
+      education of the young. For we are not developing the Nation's wealth for
+      its own sake. Wealth is the means--and people arc the ends. All our material
+      riches will avail us little if we do not use them to expand the opportunities
+      of our people. </p>
+    <p>Last year, we improved the diet of needy people--provided more hot lunches
+      and fresh milk to school children built more college dormitories--and,
+      for the elderly, expanded private housing, nursing homes, heath services,
+      and social security. But we have just begun. </p>
+    <p>To help those least fortunate of all, I am recommending a new public welfare
+      program, stressing services instead of support, rehabilitation instead
+      of relief, and training for useful work instead of prolonged dependency. </p>
+    <p>To relieve the critical shortage of doctors and dentists--and this is
+      a matter which should concern us all--and expand research, I urge action
+      to aid medical and dental colleges and scholarships and to establish new
+      National Institutes of Health. </p>
+    <p>To take advantage of modern vaccination achievements, I am proposing a
+      mass immunization program, aimed at the virtual elimination of such ancient
+      enemies of our children as polio, diphtheria, whooping cough, and tetanus. </p>
+    <p>To protect our consumers from the careless and the unscrupulous, I shall
+      recommend improvements in the Food and Drug laws-strengthening inspection
+      and standards, halting unsafe and worthless products, preventing misleading
+      labels, and cracking down on the illicit sale of habit-forming drugs. </p>
+    <p>But in matters of health, no piece of unfinished business is more
+      important or more urgent than the enactment under the social security system
+      of health insurance for the aged. </p>
+    <p>For our older citizens have longer and more frequent illnesses,
+      higher hospital and medical bills and too little income to pay them. Private
+      health insurance helps very few--for its cost is high and its coverage
+      limited. Public welfare cannot help those too proud to seek relief but
+      hard-pressed to pay their own bills. Nor can their children or grandchildren
+      always sacrifice their own health budgets to meet this constant drain. </p>
+    <p>Social security has long helped to meet the hardships of retirement, death,
+      and disability. I now urge that its coverage be extended without further
+      delay to provide health insurance for the elderly. </p>
+    <p>EDUCATION </p>
+    <p>Equally important to our strength is the quality of our education. Eight
+      million adult Americans are classified as functionally illiterate. This
+      is a disturbing figure--reflected in Selective Service rejection rates-reflected
+      in welfare rolls and crime rates. And I shall recommend plans for a massive
+      attack to end this adult illiteracy. </p>
+    <p>I shall also recommend bills to improve educational quality, to stimulate
+      the arts, and, at the college level, to provide Federal loans for the construction
+      of academic facilities and federally financed scholarships. </p>
+    <p>If this Nation is to grow in wisdom and strength, then every able high
+      school graduate should have the opportunity to develop his talents. Yet
+      nearly half lack either the funds or the facilities to attend college.
+      Enrollments are going to double in our colleges in the short space of 10
+      years. The annual cost per student is skyrocketing to astronomical levels--now
+      averaging $1,650 a year, although almost half of our families earn less
+      than $5,000. They cannot afford such costs--but this Nation cannot afford
+      to maintain its military power and neglect its brainpower. </p>
+    <p>But excellence in education must begin at the elementary level. I sent
+      to the Congress last year a proposal for Federal aid to public school construction
+      and teachers' salaries. I believe that bill, which passed the Senate and
+      received House Committee approval, offered the minimum amount required
+      by our needs and--in terms of across-the-board aid--the maximum scope permitted
+      by our Constitution. I therefore see no reason to weaken or withdraw that
+      bill: and I urge its passage at this session. </p>
+    <p>&quot;Civilization,&quot; said H. G. Wells, &quot;is a race between education
+      and catastrophe.&quot; It is up to you in this Congress to determine the
+      winner of that race. </p>
+    <p>These are not unrelated measures addressed to specific gaps or grievances
+      in our national life. They are the pattern of our intentions and the foundation
+      of our hopes. &quot;I believe in democracy,&quot; said Woodrow Wilson, &quot;because
+      it releases the energy of every human being.&quot; The dynamic of democracy
+      is the power and the purpose of the individual, and the policy of this
+      administration is to give to the individual the opportunity to realize
+      his own highest possibilities. </p>
+    <p>Our program is to open to all the opportunity for steady and productive
+      employment, to remove from all the handicap of arbitrary or irrational
+      exclusion, to offer to all the facilities for education and health and
+      welfare, to make society the servant of the individual and the individual
+      the source of progress, and thus to realize for all the full promise of
+      American life. </p>
+    <p>IV. OUR GOALS ABROAD </p>
+    <p>All of these efforts at home give meaning to our efforts abroad. Since
+      the close of the Second World War, a global civil war has divided and tormented
+      mankind. But it is not our military might, or our higher standard of living,
+      that has most distinguished us from our adversaries. It is our belief that
+      the state is the servant of the citizen and not his master. </p>
+    <p>This basic clash of ideas and wills is but one of the forces reshaping
+      our globe--swept as it is by the tides of hope and fear, by crises in the
+      headlines today that become mere footnotes tomorrow. Both the successes
+      and the setbacks of the past year remain on our agenda of unfinished business.
+      For every apparent blessing contains the seeds of danger--every area of
+      trouble gives out a ray of hope--and the one unchangeable certainty is
+      that nothing is certain or unchangeable. </p>
+    <p>Yet our basic goal remains the same: a peaceful world community
+      of free and independent states--free to choose their own future and their
+      own system, so long as it does not threaten the freedom of others.<br>
+  Some may choose forms and ways that we would not choose for ourselves--but
+  it is not for us that they are choosing. We can welcome diversity--the Communists
+  cannot. For we offer a world of choice--they offer the world of coercion. And
+  the way of the past shows dearly that freedom, not coercion, is the wave of
+  the future. At times our goal has been obscured by crisis or endangered by
+  conflict--but it draws sustenance from five basic sources of strength:<br>
+  --the moral and physical strength of the United States;<br>
+  --the united strength of the Atlantic Community;<br>
+  --the regional strength of our Hemispheric relations;<br>
+  --the creative strength of our efforts in the new and developing nations; and<br>
+  --the peace-keeping strength of the United Nations. </p>
+    <p>V. OUR MILITARY STRENGTH </p>
+    <p>Our moral and physical strength begins at home as already discussed. But
+      it includes our military strength as well. So long as fanaticism and fear
+      brood over the affairs of men, we must arm to deter others from aggression. </p>
+    <p>In the past 12 months our military posture has steadily improved. We increased
+      the previous defense budget by 15 percent--not in the expectation of war
+      but for the preservation of peace. We more than doubled our acquisition
+      rate of Polaris submarines--we doubled the production capacity for Minuteman
+      missiles--and increased by 50 percent the number of manned bombers standing
+      ready on a 15 minute alert. This year the combined force levels planned
+      under our new Defense budget--including nearly three hundred additional
+      Polaris and Minuteman missiles--have been precisely calculated to insure
+      the continuing strength of our nuclear deterrent. </p>
+    <p>But our strength may be tested at many levels. We intend to have at all
+      times the capacity to resist non-nuclear or limited attacks--as a complement
+      to our nuclear capacity, not as a substitute. We have rejected any all-or-nothing
+      posture which would leave no choice but inglorious retreat or unlimited
+      retaliation. </p>
+    <p>Thus we have doubled the number of ready combat divisions in the Army's
+      strategic reserve--increased our troops in Europe--built up the Marines--added
+      new sealift and airlift capacity--modernized our weapons and ammunition--expanded
+      our anti-guerrilla forces--and increased the active fleet by more than
+      70 vessels and our tactical air forces by nearly a dozen wings. </p>
+    <p>Because we needed to reach this higher long-term level of readiness more
+      quickly, 155,000 members of the Reserve and National Guard were activated
+      under the Act of this Congress. Some disruptions and distress were inevitable.
+      But the overwhelming majority bear their burdens--and their Nation's burdens--with
+      admirable and traditional devotion. </p>
+    <p>In the coming year, our reserve programs will be revised--two Army Divisions
+      will, I hope, replace those Guard Divisions on duty--and substantial other
+      increases will boost our Air Force fighter units, the procurement of equipment,
+      and our continental defense and warning efforts. The Nation's first serious
+      civil defense shelter program is under way, identifying, marking, and stocking
+      50 million spaces; and I urge your approval of Federal incentives for the
+      construction of public fall-out shelters in schools and hospitals and similar
+      centers. </p>
+    <p>VI. THE UNITED NATIONS </p>
+    <p>But arms alone are not enough to keep the peace--it must be kept by men.
+      Our instrument and our hope is the United Nations-and I see little merit
+      in the impatience of those who would abandon this imperfect world instrument
+      because they dislike our imperfect world. For the troubles of a world organization
+      merely reflect the troubles of the world itself. And if the organization
+      is weakened, these troubles can only increase. We may not always agree
+      with every detailed action taken by every officer of the United Nations,
+      or with every voting majority. But as an institution, it should have in
+      the future, as it has had in the past since its inception, no stronger
+      or more faithful member than the United States of America. </p>
+    <p>In 1961 the peace-keeping strength of the United Nations was reinforced.
+      And those who preferred or predicted its demise, envisioning a troika in
+      the seat of Hammarskiold--or Red China inside the Assembly-have seen instead
+      a new vigor, under a new Secretary General and a fully independent Secretariat.
+      In making plans for a new forum and principles on disarmament for peace-keeping
+      in outer space--for a decade of development effort--the UN fulfilled its
+      Charter's lofty aim. </p>
+    <p>Eighteen months ago the tangled and turbulent Congo presented the UN with
+      its gravest challenge. The prospect was one of chaos--or certain big-power
+      confrontation, with all of its hazards and all of its risks, to us and
+      to others. Today the hopes have improved for peaceful conciliation within
+      a united Congo. This is the objective of our policy in this important area. </p>
+    <p>No policeman is universally popular-particularly when he uses his stick
+      to restore law and order on his beat. Those members who are willing to
+      contribute their votes and their views--but very little else--have created
+      a serious deficit by refusing to pay their share of special UN assessments.
+      Yet they do pay their annual assessments to retain their votes--and a new
+      UN Bond issue, financing special operations for the next 18 months, is
+      to be repaid with interest from these regular assessments. This is clearly
+      in our interest. It will not only keep the UN solvent, but require all
+      voting members to pay their fair share of its activities. Our share of
+      special operations has long been much higher than our share of the annual
+      assessment--and the bond issue will in effect reduce our disproportionate
+      obligation, and for these reasons, I am urging Congress to approve our
+      participation. </p>
+    <p>With the approval of this Congress, we have undertaken in the past year
+      a great new effort in outer space. Our aim is not simply to be first on
+      the moon, any more than Charles Lindbergh's real aim was to be the first
+      to Paris. His aim was to develop the techniques of our own country and
+      other countries in the field of air and the atmosphere, and our objective
+      in making this effort, which we hope will place one of our citizens on
+      the moon, is to develop in a new frontier of science, commerce and cooperation,
+      the position of the United States and the Free World. </p>
+    <p>This Nation belongs among the first to explore it, and among the first--if
+      not the first--we shall be. We are offering our know-how and our
+      cooperation to the United Nations. Our satellites will soon
+      be providing other nations with improved weather observations. And I shall
+      soon send to the Congress a measure to govern the financing and operation
+      of an International Communications Satellite system, in a manner consistent
+      with the public interest and our foreign policy. </p>
+    <p>But peace in space will help us naught once peace on earth is gone. World
+      order will be secured only when the whole world has laid down these weapons
+      which seem to offer us present security but threaten the future survival
+      of the human race. That armistice day seems very far away. The vast resources
+      of this planet are being devoted more and more to the means of destroying,
+      instead of enriching, human life. </p>
+    <p>But the world was not meant to be a prison in which man awaits his execution.
+      Nor has mankind survived the tests and trials of thousands of years to
+      surrender everything-including its existence--now. This Nation has the
+      will and the faith to make a supreme effort to break the log jam on disarmament
+      and nuclear tests--and we will persist until we prevail, until the rule
+      of law has replaced the ever dangerous use of force. </p>
+    <p>VII. LATIN AMERICA </p>
+    <p>I turn now to a prospect of great promise: our Hemispheric relations.
+      The Alliance for Progress is being rapidly transformed from proposal to
+      program. Last month in Latin America I saw for myself the quickening of
+      hope, the revival of confidence, the new trust in our country--among workers
+      and farmers as well as diplomats. We have pledged our help in speeding
+      their economic, educational, and social progress. The Latin American Republics
+      have in turn pledged a new and strenuous effort of self-help and self-reform. </p>
+    <p>To support this historic undertaking, I am proposing--under the authority
+      contained in the bills of the last session of the Congress--a special long-term
+      Alliance for Progress fund of $3 billion. Combined with our Food for Peace,
+      Export-Import Bank, and other resources, this will provide more than $1
+      billion a year in new support for the Alliance. In addition, we have increased
+      twelve-fold our Spanish and Portuguese language broadcasting in Latin America,
+      .and improved Hemispheric trade and defense. And while the blight of communism
+      has been increasingly exposed and isolated in the Americas, liberty has
+      scored a gain. The people of the Dominican Republic, with our firm encouragement
+      and help, and those of our sister Republics of this Hemisphere are safely
+      passing through the treacherous course from dictatorship through disorder
+      towards democracy. </p>
+    <p>VIII. THE NEW AND DEVELOPING NATIONS </p>
+    <p>Our efforts to help other new or developing nations, and to strengthen
+      their stand for freedom, have also made progress. A newly unified Agency
+      for International Development is reorienting our foreign assistance to
+      emphasize long-term development loans instead of grants, more economic
+      aid instead of military, individual plans to meet the individual needs
+      of the nations, and new standards on what they must do to marshal their
+      own resources. </p>
+    <p>A newly conceived Peace Corps is winning friends and helping people in
+      fourteen countries--supplying trained and dedicated young men and women,
+      to give these new nations a hand in building a society, and a glimpse of
+      the best that is in our country. If there is a problem here, it is that
+      we cannot supply the spontaneous and mounting demand. </p>
+    <p>A newly-expanded Food for Peace Pro-. gram is feeding the hungry of many
+      lands with the abundance of our productive farms--providing lunches for
+      children in school, wages for economic development, relief for the victims
+      of flood and famine, and a better diet for millions whose daily bread is
+      their chief concern. </p>
+    <p>These programs help people; and, by helping people, they help freedom.
+      The views of their governments may sometimes be very different from ours--but
+      events in Africa, the Middle East, and Eastern Europe teach us never to
+      write off any nation as lost to the Communists- That is the lesson of our
+      time. We support the independence of those newer or weaker states whose
+      history, geography, economy or lack of power impels them to remain outside &quot;entangling
+      alliances&quot;--as we did for more than a century. For the independence
+      of nations is a bar to the Communists' &quot;grand design&quot;-it is the
+      basis of our own. </p>
+    <p>In the past year, for example, we have urged a neutral and independent
+      Laos-regained there a common policy with our major allies--and insisted
+      that a cease-fire precede negotiations. While a workable formula for supervising
+      its independence is still to be achieved, both the spread of war-which
+      might have involved this country also--and a Communist occupation have
+      thus far been prevented. </p>
+    <p>A satisfactory settlement in Laos would also help to achieve and safeguard
+      the peace in Viet-Nam--where the foe is increasing his tactics of terror--where
+      our own efforts have been stepped up--and where the local government has
+      initiated new programs and reforms to broaden the base of resistance. The
+      systematic aggression now bleeding that country is not a &quot;war of liberation&quot;--for
+      Viet-Nam is already free. It is a war of attempted subjugation--and it
+      will be resisted. </p>
+    <p>IX. THE ATLANTIC COMMUNITY </p>
+    <p>Finally, the united strength of the Atlantic Community has flourished
+      in the last year under severe tests. NATO has increased both the number
+      and the readiness of its air, ground, and naval units--both its nuclear
+      and non-nuclear capabilities. Even greater efforts by all its members are
+      still required. Nevertheless our unity of purpose and will has been, I
+      believe, immeasurably strengthened. </p>
+    <p>The threat to the brave city of Berlin remains. In these last 6 months
+      the Allies have made it unmistakably clear that our presence in Berlin,
+      our free access thereto, and the freedom of two million West Berliners
+      would not be surrendered either to force or through appeasement--and to
+      maintain those rights and obligations, we are prepared to talk, when appropriate,
+      and to fight, if necessary. Every member of NATO stands with us in a common
+      commitment to preserve this symbol of free man's will to remain free. </p>
+    <p>I cannot now predict the course of future negotiations over Berlin. I
+      can only say that we are sparing no honorable effort to find a peaceful
+      and mutually acceptable resolution of this problem. I believe such a resolution
+      can be found, and with it an improvement in our relations with the Soviet
+      Union, if only the leaders in the Kremlin will recognize the basic rights
+      and interests involved, and the interest of all mankind in peace. </p>
+    <p>But the Atlantic Community is no longer concerned with purely military
+      aims. As its common undertakings grow at an ever-increasing pace, we are,
+      and increasingly will be, partners in aid, trade, defense, diplomacy, and
+      monetary affairs. </p>
+    <p>The emergence of the new Europe is being matched by the emergence of new
+      ties across the Atlantic. It is a matter of undramatic daily cooperation
+      in hundreds of workaday tasks: of currencies kept in effective relation,
+      of development loans meshed together, of standardized weapons, and concerted
+      diplomatic positions. The Atlantic Community grows, not like a volcanic
+      mountain, by one mighty explosion, but like a coral reef, from the accumulating
+      activity of all. </p>
+    <p>Thus, we in the free world are moving steadily toward unity and cooperation,
+      in the teeth of that old Bolshevik prophecy, and at the very time when
+      extraordinary rumbles of discord can be heard across the Iron Curtain.
+      It is not free societies which bear within them the seeds of inevitable
+      disunity. </p>
+    <p>X. OUR BALANCE OF PAYMENTS </p>
+    <p>On one special problem, of great concern to our friends, and to us, I
+      am proud to give the Congress an encouraging report. Our efforts to safeguard
+      the dollar are progressing. In the 11 months preceding last February
+      1, we suffered a net loss of nearly $2 billion in gold. In the 11 months
+      that followed, the loss was just over half a billion dollars. And our deficit
+      in our basic transactions with the rest of the world--trade, defense, foreign
+      aid, and capital, excluding volatile short-term flows--has been reduced
+      from $2 billion for 1960 to about one-third that amount for 1961. Speculative
+      fever against the dollar is ending--and confidence in the dollar has been
+      restored. </p>
+    <p>We did not--and could not--achieve these gains through import restrictions,
+      troop withdrawals, exchange controls, dollar devaluation or choking off
+      domestic recovery. We acted not in panic but in perspective. But the problem
+      is not yet solved. Persistently large deficits would endanger our economic
+      growth and our military and defense commitments abroad. Our goal must be
+      a reasonable equilibrium in our balance of payments. With the cooperation
+      of the Congress, business, labor, and our major allies, that goal can be
+      reached. </p>
+    <p>We shall continue to attract foreign tourists and investments to our shores,
+      to seek increased military purchases here by our allies, to maximize foreign
+      aid procurement from American firms, to urge increased aid from other fortunate
+      nations to the less fortunate, to seek tax laws which do not favor investment
+      in other industrialized nations or tax havens, and to urge coordination
+      of allied fiscal and monetary policies So as to discourage large and disturbing
+      capital movements. </p>
+    <p>TRADE </p>
+    <p>Above all, if we are to pay for our commitments abroad, we must expand
+      our exports. Our businessmen must be export conscious and export competitive.
+      Our tax policies must spur modernization of our plants--our wage and price
+      gains must be consistent with productivity to hold the line on prices--our
+      export credit and promotion campaigns for American industries must continue
+      to expand. </p>
+    <p>But the greatest challenge of all is posed by the growth of the European
+      Common Market. Assuming the accession of the United Kingdom, there will
+      arise across the Atlantic a trading partner behind a single external tariff
+      similar to ours with an economy which nearly equals our own. Will we in
+      this country adapt our thinking to these new prospects and patterns--or
+      will we wait until events have passed us by? </p>
+    <p>This is the year to decide. The Reciprocal Trade Act is expiring. We need
+      a new law--a wholly new approach--a bold new instrument of American trade
+      policy. Our decision could well affect the unity of the West, the course
+      of the Cold War, and the economic growth of our Nation for a generation
+      to come. </p>
+    <p>If we move decisively, our factories and farms can increase their sales
+      to their richest, fastest-growing market. Our exports will increase. Our
+      balance of payments position will improve. And we will have forged across
+      the Atlantic a trading partnership with vast resources for freedom. </p>
+    <p>If, on the other hand, we hang back in deference to local economic pressures,
+      we will find ourselves cut off from our major allies. Industries--and I
+      believe this is most vital--industries will move their plants and jobs
+      and capital inside the walls of the Common Market, and jobs, therefore,
+      will be lost here in the United States if they cannot otherwise compete
+      for its consumers. Our farm surpluses--our balance of trade, as you all
+      know, to Europe, the Common Market, in farm products, is nearly three or
+      four to one in our favor, amounting to one of the best earners of dollars
+      in our balance of payments structure, and without entrance to this Market,
+      without the ability to enter it, our farm surpluses will pile up in the
+      Middle West, tobacco in the South, and other commodities, which have gone
+      through Western Europe for 15 years. Our balance of payments position will
+      worsen. Our consumers, will lack a wider choice of goods at lower prices.
+      And millions of American workers-whose jobs depend on the sale or the transportation
+      or the distribution of exports or imports, or whose jobs will be endangered
+      by the movement of our capital to Europe, or whose jobs can be maintained
+      only in. an expanding economy--these millions of workers in your home States
+      and mine will see their real interests sacrificed. </p>
+    <p>Members of the Congress: The United States did not rise to greatness by
+      waiting for others to lead. This Nation is the world's foremost manufacturer,
+      farmer, banker, consumer, and exporter. The Common Market is moving ahead
+      at an economic growth rate twice ours. The Communist economic offensive
+      is under way. The opportunity is ours--the initiative is up to us--and
+      I believe that 1962 is the time. </p>
+    <p>To seize that initiative, I shall shortly send to the Congress a new five-year
+      Trade Expansion Action, far-reaching in scope but designed with great care
+      to make certain that its benefits to our people far outweigh any risks.
+      The bill will permit the gradual elimination of tariffs here in the United
+      States and in the Common Market on those items in which we together supply
+      80 percent of the world's trade--mostly items in which our own ability
+      to compete is demonstrated by the fact that we sell abroad, in these items,
+      substantially more than we import. This step will make it possible for
+      our major industries to compete with their counterparts in Western Europe
+      for access to European consumers. </p>
+    <p>On other goods the bill will permit a gradual reduction of duties up to
+      50 percent-permitting bargaining by major categories-and provide for appropriate
+      and tested forms of assistance to firms and employees adjusting to import
+      competition. We are not neglecting the safeguards provided by peril points,
+      an escape clause, or the National Security Amendment. Nor are we abandoning
+      our non-European friends or our traditional &quot;most-favored nation&quot; principle.
+      On the contrary, the bill will provide new encouragement for their sale
+      of tropical agricultural products, so important to our friends in Latin
+      America, who have long depended upon the European market, who now find
+      themselves faced with new challenges which we must join with them in overcoming. </p>
+    <p>Concessions, in this bargaining, must of course be reciprocal, not unilateral.
+      The Common Market will not fulfill its own high promise unless its outside
+      tariff walls are low. The dangers of restriction or timidity in our own
+      policy have counterparts for our friends in Europe. For together we face
+      a common challenge: to enlarge the prosperity of free men everywhere--to
+      build in partnership a new trading community in which all free nations
+      may gain from the productive energy of free competitive effort. </p>
+    <p>These various elements in our foreign policy lead, as I have said, to
+      a single goal--the goal of a peaceful world of free and independent states.
+      This is our guide for the present and our vision for the future--a free
+      community of nations, independent but interdependent, uniting north and
+      south, east and west, in one great family of man, outgrowing and transcending
+      the hates and fears that rend our age. </p>
+    <p>We will not reach that goal today, or tomorrow. We may not reach it in
+      our own lifetime. But the quest is the greatest adventure of our century.
+      We sometimes chafe at the burden of our obligations, the complexity of
+      our decisions, the agony of our choices. But there is no comfort or security
+      for us in evasion, no solution in abdication, no relief in irresponsibility. </p>
+    <p>A year ago, in assuming the tasks of the Presidency, I said that few generations,
+      in all history, had been granted the role of being the great defender of
+      freedom in its hour of maximum danger. This is our good fortune; and I
+      welcome it now as I did a year ago. For it is the fate of this generation-of
+      you in the Congress and of me as President--to live with a struggle we
+      did not start, in a world we did not make. But the pressures of life are
+      not always distributed by choice. And while no nation has ever faced such
+      a challenge, no nation has ever been so ready to seize the burden and the
+      glory of freedom. </p>
+    <p> And
+      in this high endeavor, may God watch over the United States of America. </p>
+      </div>
+<p></p></div> 
+
+<div id="footer"><span><a href="http://www.thisnation.com/about.html">About this Site</a> &#8226; <a href="mailto:info@thisnation.com">Contact Us</a> &#8226; <a href="">Permissions</a> 
+<br>
+<script type="text/javascript"><!--
+google_ad_client = "pub-4028468449272970";
+/* 468x60, created 8/14/08 */
+google_ad_slot = "2920419469";
+google_ad_width = 468;
+google_ad_height = 60;
+//-->
+</script>
+<script type="text/javascript"
+src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
+</script>
+</span>
+  <br>
+  <div class="foot"><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a> This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/deed.en_US">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.</div>
+<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
+</script>
+<script type="text/javascript">
+_uacct = "UA-272911-1";
+urchinTracker();
+</script>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-43460377-1', 'thisnation.com');
+  ga('send', 'pageview');
+
+</script>
+</div> 
+
+</body>
+</html>

--- a/DiscoveryV2.playground/contents.xcplayground
+++ b/DiscoveryV2.playground/contents.xcplayground
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios'>
+    <pages>
+        <page name='Introduction'/>
+        <page name='Collections'/>
+        <page name='Queries'/>
+        <page name='Component settings'/>
+        <page name='Documents'/>
+        <page name='Training data'/>
+    </pages>
+</playground>

--- a/WatsonPlaygrounds.xcworkspace/contents.xcworkspacedata
+++ b/WatsonPlaygrounds.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:DiscoveryV2.playground">
+   </FileRef>
+   <FileRef
       location = "group:README.md">
    </FileRef>
    <FileRef


### PR DESCRIPTION
This adds DiscoveryV2 examples to the playground. These will not be runnable right now since the framework isn't available yet in the SDK. This will also require a user to have a CP4D cluster in order to run.